### PR TITLE
fix nested behave for JsonRepeatable

### DIFF
--- a/src/Fields/JsonRepeatable.php
+++ b/src/Fields/JsonRepeatable.php
@@ -28,30 +28,59 @@ class JsonRepeatable extends Field
         return Util::value(data_get($resource, str_replace('->', '.', $attribute)));
     }
 
-    public function fill(NovaRequest $request, $model)
+    public function fill(NovaRequest $request, $model, string $nestedAttribute = null)
     {
-        $model->{$this->attribute} = null;
+        $this->fillModelWithData($model, null, $nestedAttribute ?? $this->attribute);
 
         foreach(($request[$this->attribute] ?? []) as $index => $fieldset) {
             foreach($this->fields as $field) {
+                /** @var Field $field */
+
+                $attributeKeys = [
+                    $index,
+                    $field->attribute,
+                ];
+
+                array_unshift($attributeKeys, $nestedAttribute ?? $this->attribute);
+
+                $attribute = implode('->', $attributeKeys);
+
+                if ($field instanceof self) {
+                    $field->fill(
+                        request: new NovaRequest($request[$this->attribute][$index]),
+                        model: $model,
+                        nestedAttribute: $attribute
+                    );
+
+                    continue;
+                }
+
                 $field->fillAttribute(
                     request: new NovaRequest($request[$this->attribute][$index]),
                     requestAttribute: $field->attribute,
                     model: $model,
-                    attribute: "{$this->attribute}->{$index}->{$field->attribute}",
+                    attribute: $attribute,
                 );
             }
         }
     }
 
-    public function getRules(NovaRequest $request)
+    public function getRules(NovaRequest $request, string $nestedAttribute = null)
     {
         $rules = [
-            $this->attribute => is_callable($this->rules) ? call_user_func($this->rules, $request) : $this->rules,
+            $nestedAttribute ?? $this->attribute => is_callable($this->rules) ? call_user_func($this->rules, $request) : $this->rules,
         ];
 
         foreach($this->fields as $field) {
-            $rules["{$this->attribute}.*.{$field->attribute}"] = is_callable($field->rules) ? call_user_func($field->rules, $request) : $field->rules;
+            $key = $nestedAttribute ?? $this->attribute;
+
+            if ($field instanceof self) {
+                $rules = array_merge($rules, $field->getRules($request, "{$key}.*.{$field->attribute}"));
+
+                continue;
+            }
+
+            $rules["{$key}.*.{$field->attribute}"] = $field->getRules($request)[$field->attribute];
         }
 
         return $rules;


### PR DESCRIPTION
Found that JsonRepeatable behave incorect when it has nested structure. Let's take a look at request example:
`
"json_repeatable": 
    [
        {
            "title": "Title 1",
            "badge": "badge 1",
            "nested_json_repeatable": [
                {
                    "uuid": "891e1a21-c655-40c2-9026-7e2c7b52b285",
                    "title": "nested 1 title 1",
                    "url": "http://localhost/1_1",
                    "description": "Description 1"
                },
                {
                    "uuid": "ef20be68-7510-4455-9a39-67185005fe34",
                    "title": "nested 1 title 2",
                    "url": "http://localhost/1_2",
                    "description": "Description 2"
                }
            ]
        },
        {
            "title": "Title 2",
            "content": [
                {
                    "uuid": "9c324bee-c55d-40e5-a7a0-55b2ac6ac752",
                    "title": "nested 2 title 2",
                    "url": "http://localhost/2_2",
                    "description": "Description 2"
                }
            ]
        }
    ]
`
So what did I found is that JsonRepeatable does not fill values field by field when JsonRepeatable is inside other JsonRepeatable, it directly takes whole array from request by key (nested_json_repeatable from my example) and put it to model's value without any validation as validation rules also broken when JsonRepeatable is nested.
This merge request adds, I would call it, "pseudo" recursion for nested JsonRepeatable and nested rules