### PR TITLE
fix: types missing for `5.0`.

### DIFF
--- a/src/Fields/JsonRepeatable.php
+++ b/src/Fields/JsonRepeatable.php
@@ -23,7 +23,7 @@ class JsonRepeatable extends Field
         return $this;
     }
 
-    protected function resolveAttribute($resource, $attribute)
+    protected function resolveAttribute($resource, $attribute): mixed
     {
         return Util::value(data_get($resource, str_replace('->', '.', $attribute)));
     }
@@ -44,7 +44,7 @@ class JsonRepeatable extends Field
         }
     }
 
-    public function getRules(NovaRequest $request)
+    public function getRules(NovaRequest $request): array
     {
         $rules = [
             $this->attribute => is_callable($this->rules) ? call_user_func($this->rules, $request) : $this->rules,

--- a/src/Fields/JsonRepeatable.php
+++ b/src/Fields/JsonRepeatable.php
@@ -23,7 +23,7 @@ class JsonRepeatable extends Field
         return $this;
     }
 
-    protected function resolveAttribute($resource, $attribute): mixed
+    protected function resolveAttribute($resource, string $attribute): mixed
     {
         return Util::value(data_get($resource, str_replace('->', '.', $attribute)));
     }


### PR DESCRIPTION
Fixes issue for `5.0` that the interfaces are expecting those types.

Sorry about missing that on the #28.

Thanks