### PR TITLE
fix: add missing return type on `JsonArray` resource

### DIFF
--- a/src/Fields/JsonArray.php
+++ b/src/Fields/JsonArray.php
@@ -36,7 +36,7 @@ class JsonArray extends Field
         }
     }
 
-    public function getRules(NovaRequest $request)
+    public function getRules(NovaRequest $request): array
     {
         return [
             $this->attribute => is_callable($this->rules) ? call_user_func($this->rules, $request) : $this->rules,


### PR DESCRIPTION
This PR is similar to the previous one #29 but in this case for the `JsonArray`.

Cheers 💪